### PR TITLE
URL Cleanup

### DIFF
--- a/40-remove-compiler-syntax_tools-dependencies.patch
+++ b/40-remove-compiler-syntax_tools-dependencies.patch
@@ -7,7 +7,7 @@ index 6b20e41..0000000
 -%% @author Bob Ippolito <bob@mochimedia.com>
 -%% @copyright 2010 Mochi Media, Inc.
 -%% @doc Abuse module constant pools as a "read-only shared heap" (since erts 5.6)
--%%      <a href="http://www.erlang.org/pipermail/erlang-questions/2009-March/042503.html">[1]</a>.
+-%%      <a href="https://www.erlang.org/pipermail/erlang-questions/2009-March/042503.html">[1]</a>.
 --module(mochiglobal).
 --author("Bob Ippolito <bob@mochimedia.com>").
 --export([get/1, get/2, put/2, delete/1]).

--- a/50-remove-json.patch
+++ b/50-remove-json.patch
@@ -905,7 +905,7 @@ index c52b15c..0000000
 -%% @doc Useful numeric algorithms for floats that cover some deficiencies
 -%% in the math module. More interesting is digits/1, which implements
 -%% the algorithm from:
--%% http://www.cs.indiana.edu/~burger/fp/index.html
+-%% https://cs.indiana.edu/~burger/fp/index.html
 -%% See also "Printing Floating-Point Numbers Quickly and Accurately"
 -%% in Proceedings of the SIGPLAN '96 Conference on Programming Language
 -%% Design and Implementation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The process is fairly standard:
  * Clone [RabbitMQ umbrella repository](https://github.com/rabbitmq/rabbitmq-public-umbrella)
  * `cd umbrella`, `make co`
  * Create a branch with a descriptive name in the relevant repositories
- * Make your changes, run tests, commit with a [descriptive message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
+ * Make your changes, run tests, commit with a [descriptive message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
  * Submit pull requests with an explanation what has been changed and **why**
  * Submit a filled out and signed [Contributor Agreement](https://github.com/rabbitmq/ca#how-to-submit) if needed (see below)
  * Be patient. We will get to your pull request eventually

--- a/license_info
+++ b/license_info
@@ -1,4 +1,4 @@
 Mochiweb is "Copyright (c) 2007 Mochi Media, Inc." and is covered by
 the MIT license.  It was downloaded from
-http://github.com/mochi/mochiweb/
+https://github.com/mochi/mochiweb/
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.cs.indiana.edu/~burger/fp/index.html (301) with 1 occurrences migrated to:  
  https://cs.indiana.edu/~burger/fp/index.html ([https](https://www.cs.indiana.edu/~burger/fp/index.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/mochi/mochiweb/ with 1 occurrences migrated to:  
  https://github.com/mochi/mochiweb/ ([https](https://github.com/mochi/mochiweb/) result 200).
* http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* http://www.erlang.org/pipermail/erlang-questions/2009-March/042503.html with 1 occurrences migrated to:  
  https://www.erlang.org/pipermail/erlang-questions/2009-March/042503.html ([https](https://www.erlang.org/pipermail/erlang-questions/2009-March/042503.html) result 301).